### PR TITLE
Use transparent Juice Junkies logo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/index.html
+++ b/public/index.html
@@ -16,8 +16,6 @@
       <div class="hero__inner">
         <div class="brand">
           <img src="./juice-junkies-logo.svg" alt="Juice Junkies Logo" class="logo">
-          <h1 class="brand__title">SALAMI SLIDER</h1>
-          <div class="brand__tag">LOUD • BOLD • 2000s SPORTS BAR</div>
         </div>
 
         <div class="hero__totals">

--- a/public/juice-junkies-logo.svg
+++ b/public/juice-junkies-logo.svg
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 420">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 280">
   <defs>
-    <!-- Chrome gradient for fill -->
     <linearGradient id="chrome" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%"  stop-color="#f6f9ff"/>
       <stop offset="22%" stop-color="#dfe6f2"/>
@@ -11,13 +10,11 @@
       <stop offset="100%" stop-color="#eef3ff"/>
     </linearGradient>
 
-    <!-- Neon stroke gradient -->
     <linearGradient id="neon" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%" stop-color="#00E5FF"/>
       <stop offset="100%" stop-color="#FF0066"/>
     </linearGradient>
 
-    <!-- Outer glow -->
     <filter id="outerGlow" x="-30%" y="-50%" width="160%" height="200%">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur"/>
       <feColorMatrix in="blur" type="matrix"
@@ -31,13 +28,11 @@
       </feMerge>
     </filter>
 
-    <!-- Inner glow/highlight -->
     <filter id="innerGlow" x="-10%" y="-10%" width="120%" height="120%">
       <feGaussianBlur stdDeviation="2" result="b"/>
       <feComposite in="SourceGraphic" in2="b" operator="arithmetic" k2="1" k3="-0.7"/>
     </filter>
 
-    <!-- Soft drop shadow -->
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="160%">
       <feOffset dy="6" dx="0" result="off"/>
       <feGaussianBlur in="off" stdDeviation="8" result="blur2"/>
@@ -52,39 +47,17 @@
       </feMerge>
     </filter>
 
-    <!-- Stroke outline as reusable style -->
     <style><![CDATA[
-      .plate { fill: none; stroke: url(#neon); stroke-width: 10; filter: url(#outerGlow); }
-      .word { font: 900 220px/1 'Bebas Neue', 'Anton', Impact, 'Arial Black', sans-serif;
-              fill: url(#chrome); paint-order: stroke; stroke: url(#neon); stroke-width: 10;
-              letter-spacing: 10px; filter: url(#innerGlow); }
-      .sub  { font: 600 56px/1 'Oswald', 'Bebas Neue', Impact, sans-serif; letter-spacing: 6px;
-              fill: #e8edf6; opacity: .9; }
-      .badge { font: 900 120px/1 'Bebas Neue', 'Anton', Impact, sans-serif; }
+      .badge { font: 900 120px/1 'Bebas Neue','Anton', Impact, sans-serif; }
     ]]></style>
   </defs>
 
-  <!-- Wordmark group -->
-  <g transform="translate(40,285)">
-    <!-- Subtle underline plate -->
-    <path class="plate" d="M10,90 H1510" />
-    <!-- Main wordmark -->
-    <text class="word" y="0">JUICE&nbsp;JUNKIES</text>
-    <!-- Tagline (optional; delete if not needed) -->
-    <text class="sub" y="120">SPORTS&nbsp;BAR&nbsp;EDITION</text>
-  </g>
-
-  <!-- Circular JJ badge at left (can be used standalone if desired) -->
-  <g transform="translate(40,40)">
-    <g filter="url(#shadow)">
-      <circle cx="140" cy="140" r="118" fill="none" stroke="url(#neon)" stroke-width="12" filter="url(#outerGlow)"/>
-      <circle cx="140" cy="140" r="92"  fill="none" stroke="url(#neon)" stroke-width="6" opacity=".65"/>
-      <g transform="translate(140,140)">
-        <text class="badge" text-anchor="middle" dominant-baseline="central"
-              fill="url(#chrome)" stroke="url(#neon)" stroke-width="8" filter="url(#innerGlow)">
-          JJ
-        </text>
-      </g>
+  <g filter="url(#shadow)">
+    <circle cx="140" cy="140" r="118" fill="none" stroke="url(#neon)" stroke-width="12" filter="url(#outerGlow)"/>
+    <circle cx="140" cy="140" r="92"  fill="none" stroke="url(#neon)" stroke-width="6" opacity=".65"/>
+    <g transform="translate(140,140)">
+      <text class="badge" text-anchor="middle" dominant-baseline="central"
+            fill="url(#chrome)" stroke="url(#neon)" stroke-width="8" filter="url(#innerGlow)">JJ</text>
     </g>
   </g>
 </svg>

--- a/public/styles.css
+++ b/public/styles.css
@@ -13,7 +13,6 @@ body{
   font-family: "Oswald", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
 }
 .hero{position:relative; padding:16px 12px 0; border-bottom:1px solid rgba(255,255,255,0.08); overflow:hidden}
-.hero--tight .brand__title{font-size: clamp(36px, 6vw, 64px)}
 .hero__glow{position:absolute; inset:-20% -10% auto -10%; height:120%;
   background: radial-gradient(closest-side, rgba(0,229,255,0.18), transparent 70%);
   filter: blur(40px); pointer-events:none;
@@ -21,16 +20,8 @@ body{
 .hero__inner{max-width:1100px; margin:0 auto; padding:0 8px 10px; display:grid; gap:12px; align-items:end; grid-template-columns:1fr}
 @media(min-width:900px){ .hero__inner{ grid-template-columns: 1.1fr 1fr } }
 
-.brand{display:flex; flex-direction:column; gap:6px; text-transform:uppercase}
-.brand__title{
-  margin:0; font-family:"Anton","Bebas Neue","Oswald", Impact, Arial Black, sans-serif;
-  letter-spacing:1px; line-height:0.9;
-  background: linear-gradient(180deg, #e9f1ff, #b3c0d6 45%, #7a8799 60%, #e4ebf6 90%);
-  -webkit-background-clip:text; background-clip:text; color:transparent;
-  text-shadow: 0 3px 0 rgba(0,0,0,0.35), 0 10px 18px rgba(0,0,0,0.6);
-}
-.brand__tag{font-size:12px; opacity:0.8; letter-spacing:2px}
-.logo{max-width:200px; width:70%; height:auto; display:block; margin-bottom:8px}
+.brand{display:flex; justify-content:center;}
+.logo{max-width:300px; width:100%; height:auto; display:block}
 
 .hero__totals{display:grid; gap:10px}
 .total{


### PR DESCRIPTION
## Summary
- Replace binary PNG logo with scalable SVG badge and reference it in the header
- Add `.gitignore` to exclude `node_modules`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c25f70a1dc83298c10d44db660dce3